### PR TITLE
Update Dockerfile to use Debian base 8.0.0 and revert NUT version to …

### DIFF
--- a/addon-nut/nut/Dockerfile
+++ b/addon-nut/nut/Dockerfile
@@ -1,27 +1,21 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:7.8.3
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:8.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
 # Setup base
 # hadolint ignore=DL3003
 RUN \
-    echo 'deb http://deb.debian.org/debian testing main' > /etc/apt/sources.list.d/testing.list \
-    && apt-get update \
+    apt-get update \
     && apt-get install -y --no-install-recommends\
-    nut=2.8.3-3 \
-    nut-snmp=2.8.3-3 \
-    nut-xml=2.8.3-3 \
+    nut=2.8.1-5 \
+    nut-snmp=2.8.1-5 \
+    nut-xml=2.8.1-5 \
     usbutils=1:014-1+deb12u1 \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/testing.list
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy root filesystem
 COPY rootfs /
-
-# Make init scripts executable
-RUN chmod +x /etc/cont-init.d/*.sh && \
-    chmod +x /etc/services.d/*/* && \
-    chmod +x /usr/bin/*
 
 # Build arguments
 ARG BUILD_ARCH

--- a/addon-nut/nut/config.yaml
+++ b/addon-nut/nut/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Network UPS Tools
-version: 2.8.3.2
+version: 2.8.1
 slug: nut
 description: Manage battery backup (UPS) devices
 url: https://github.com/hassio-addons/addon-nut


### PR DESCRIPTION
…2.8.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base image to debian-base 8.0.0.
  * Updated add-on version to 2.8.1.
  * Updated installed NUT packages to 2.8.1-5.
  * Removed use of the Debian testing repository.
  * Simplified build cleanup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->